### PR TITLE
update ProDy dependency to an unrelease sha to resolve numpy conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,6 @@ install_requires =
     metaflow==2.12.28
     boltz
     DockQ
-    ProDy
+    # ProDy used to cap numpy at a version incompatible with the latest boltz; it no longer does,
+    # but that change has not made it into an official release yet.
+    ProDy @ git+https://github.com/prody/ProDy.git@2b6c563d8fcf106e76d460037e32494df34fd2e3


### PR DESCRIPTION
`boltz` depends on `numpy==1.26.3` and, until ~Sep 2024, ProDy depended on `numpy==numpy<1.24`. The upper bound on numpy version has been changed to just be `<2`, but no releases have been cut since then.

@timodonnell I know you've gotten `pip install -e .` to work in a local environment with ProDy `2.3.1`, but I really don't know how :D 

Haven't figure out a way to build this repeatably. The `Dockerfile` seems to sidestep this issue by just installing `ProDy` directly via `pip install` vs by pulling it in via `setuptools`, but I'm still not 100% sure I understand why that doesn't cause a conflict - perhaps because `numpy` is just showing up as part of `conda`, and thus does not get checked in dependency resolution. You would think it would be, since `ProDy` does add it to `INSTALL_REQUIRES`, but also does this weird [programmatic check](https://github.com/prody/ProDy/blob/main/setup.py#L15-L33) for the existence of `numpy`.. Anyway, there may be a better way around all this, but making the PR in case this comes up again later.